### PR TITLE
Changing minimum Android version (4.4 to 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements:
 - iOS at least on version 10.0
-- Android at least on version 4.4
+- Android at least on version 5
 - React Native at least on version 0.59.10
 
 ## Getting started


### PR DESCRIPTION
Appears to need an update following the `1.1.15` version changes.
Thank you.

https://github.com/Survicate/react-native-survicate/issues/30